### PR TITLE
Chore/improve local development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ### Requirements
 
-You need to install Docker in your machine if you haven't already [Docker](https://www.docker.com/)
+* You need to install Docker in your machine if you haven't already [Docker](https://www.docker.com/)
+
+* You will need [Control Tower](https://github.com/Skydipper/control-tower) up and running before run this service.
 
 ### Development
 
@@ -12,22 +14,25 @@ Follow the next steps to set up the development environment in your machine.
 
 1. Clone the repo and go to the folder
 
-```ssh
+```bash
 git clone https://github.com/resource-watch/aqueduct-analysis-microservice
+```
+
+2. Copy `.env.sample` to `.env` and set the corresponding variable values. Note if your are using GNU/Linux you have to replace `mymachine` by your local ip address.
+```bash
 cd aqueduct-analysis-microservice
+cp .env.sample .env
 ```
 
+3. Run the `aqueduct.sh` shell script in development mode.
 
-2. Copy `.env.sample` to `.env` and set the corresponding variable values
-
-```ssh
+```bash
 ./aqueduct.sh develop
 ```
 
-3. Run the aqueduct.sh shell script in development mode.
-
-```ssh
-./aqueduct.sh develop
+4. Once postgresql docker container is running we are ready to import the service database in case was not imported yet. Note postgresql docker instance port is mapped to 5432 so, if we have another service in localhost running in this port, the service won't start. To import a dump of the service database execute the following command:
+```bash
+psql -h localhost -U postgres -c "CREATE DATABASE {DATABASE_NAME}" && pg_restore -h localhost -U postgres -d {DATABASE_NAME} /PATH/TO/DUMP/FILE.sql
 ```
 
 If this is the first time you run it, it may take a few minutes.

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -14,16 +14,26 @@ services:
       DEBUG: "True"
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjU4MjBhZDk0NjlhMDI4Nzk4MmY0Y2QxOCIsInByb3ZpZGVyIjoibG9jYWwiLCJwcm92aWRlcklkIjpudWxsLCJlbWFpbCI6InNlcmdpby5nb3JkaWxsb0B2aXp6dWFsaXR5LmNvbSIsInJvbGUiOiJBRE1JTiIsImNyZWF0ZWRBdCI6IjIwMTYtMTEtMDdUMTY6MzY6MzYuODY4WiIsImV4dHJhVXNlckRhdGEiOnsiYXBwcyI6WyJnZnciLCJwcmVwIiwiYXF1ZWR1Y3QiLCJmb3Jlc3QtYXRsYXMiLCJydyIsImRhdGE0c2RnIl19fQ.3GzuhG8wD4gI5Fo6NTqHC_Dq6ChKPPWXygga2mAuKZw
       API_VERION: v1
-      POSTGRES_URL: postgresql+psycopg2://postgres@mymachine:5432/flood_v2
+      POSTGRES_URL: postgresql+psycopg2://postgres@aqueduct-postgres:5432/flood_v2
     command: develop
     volumes:
       - ./aqueduct:/opt/aqueduct/aqueduct
     restart: always
     depends_on:
       - postgres
+    networks:
+      - aqueduct_analysis-network
 
   postgres:
     image: postgres:9.6.12
     container_name: aqueduct-postgres
+    volumes:
+      - $HOME/docker/data/aqueduct-postgres:/var/lib/postgresql/data
     ports:
-      - "5432"
+      - "5432:5432"
+    networks:
+      - aqueduct_analysis-network
+
+networks:
+  aqueduct_analysis-network:
+    driver: "bridge"


### PR DESCRIPTION
#### What is the purpose of this change?

Improve the local development environment:

* Added persistence to postgresql container.
* Postgresql container port mapped to 5432 to easily interact from our host.
* Added a network to connect both containers: aqueduct_analysis-develop and aqueduct-postgres.
* Updated README file adding dependencies like control-tower.

#### How can a reviewer test this Pull Request?

* If you have another postgresql instance running in port 5432 stop it.
* If you are working with GNU/Linux ensure some local ip address is properly configured, for example: 
```bash
CT_URL=http://192.168.1.198:9000
LOCAL_URL=http://192.168.1.198:5100
```
* Execute `./aqueduct.sh develop` to start the container, ensure you have control-tower up and running before.
* Check you have a new folder in your system containing postgresql data `$HOME/docker/data/aqueduct-postgres/`
* Check if README file added content is correct.
