### PR TITLE
Add redis url env var from k8s secret

### DIFF
--- a/k8s/dev/deployment.yaml
+++ b/k8s/dev/deployment.yaml
@@ -63,6 +63,11 @@ spec:
                 secretKeyRef:
                   key: AQUEDUCT_POSTGRES_URL
                   name: dbsecrets
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_URL
+                  name: dbsecrets
             - name: AQUEDUCT_GOOGLE_PLACES_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -61,6 +61,11 @@ spec:
                 secretKeyRef:
                   key: AQUEDUCT_POSTGRES_URL
                   name: dbsecrets
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_URL
+                  name: dbsecrets
             - name: AQUEDUCT_GOOGLE_PLACES_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -63,6 +63,11 @@ spec:
                 secretKeyRef:
                   key: AQUEDUCT_POSTGRES_URL
                   name: dbsecrets
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  key: REDIS_URL
+                  name: dbsecrets
             - name: AQUEDUCT_GOOGLE_PLACES_PRIVATE_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Hey @yakloinsteak 

This adds the Redis URL you'll need on each of the 3 AWS envs. The vars will have a value like "redis://<host>:<port>

One thing that the env var value does not have, and that you should config on your side, is the redis database this app will use - please use database 3

Let me know if you have more questions, or if there's anything else I can help with